### PR TITLE
fix: using separate GitHub token

### DIFF
--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.COMM_GITHUB_TOKEN }}
           script: |
             const issueTitle = context.payload.issue.title;
             const labelsToAdd = [];


### PR DESCRIPTION
## 🔗 Issue

closed #48 .

## 📚 Description

- [x] GitHubトークンをセット
  - ref: https://github.com/actions/github-script?tab=readme-ov-file#using-a-separate-github-token

## 📝 Reviewer checklist

- [ ]  Execute `nr dev` command and check http://localhost:3000 .
